### PR TITLE
Issue 55: Updated FramesLanguages type to include all supported languages

### DIFF
--- a/src/frames/types/types.tsx
+++ b/src/frames/types/types.tsx
@@ -23,7 +23,7 @@ export interface FramesLocalization {
     cardSchemeHeader?: string;
 }
 
-export type FramesLanguages = 'EN-GB' | 'ES-ES' | 'FR-FR' | 'DE-DE' | 'KR-KR' | 'IT-IT' | 'NL-NL';
+export type FramesLanguages = 'AR' | 'ZH-CH' | 'ZH-HK' | 'ZH-TW' | 'DA-DK' | 'NL-NL' | 'EN-GB' | 'FIL-PH' | 'FI-FI' | 'FR-FR' | 'DE-DE' | 'HI-IN' | 'ID-ID' | 'IT-IT' | 'JA-JP' | 'KO-KR' | 'MS-MY' | 'NB-NO' | 'ES-ES' | 'SV-SE' | 'TH-TH' | 'VI-VN';
 
 export type FrameElementIdentifer = 'card-number' | 'expiry-date' | 'cvv';
 


### PR DESCRIPTION
This pull request addresses issue #55.

Changes made:
- Extended type FramesLanguages with all supported languages according the docs

Supported languages taken from [Get started with Frames](https://www.checkout.com/docs/payments/accept-payments/accept-a-payment-on-your-website-with-frames/get-started#Localization)